### PR TITLE
387 Fix backsearch bug

### DIFF
--- a/src/queries/query.ts
+++ b/src/queries/query.ts
@@ -5,7 +5,6 @@ import {
   Op,
   WhereOptions,
   Options,
-  where,
 } from "sequelize";
 import { Feature, MultiPolygon, Polygon } from "geojson";
 import * as turf from "@turf/turf";
@@ -1182,29 +1181,33 @@ export const getPolygonsByArea = async (searchArea: string) => {
   return polygonsAndOwnerships;
 };
 
+/**
+ * Find property polygons that are associated with a title that has a proprietor exactly matching
+ * the given name.
+ *
+ * @param name proprietor name to search for
+ * @returns an array of polygons with ownership info for each polygon that matches the proprietor name
+ */
 export const getPolygonsByProprietorName = async (name: string) => {
-  const polygonsAndOwnerships = await LandOwnershipModel.findAll({
-    where: {
-      proprietor_name_1: name,
-    },
-    include: PolygonModel,
-    raw: true,
+  const query = `SELECT land_ownerships.*,
+    land_ownership_polygons.poly_id AS poly_id,
+    land_ownership_polygons.geom AS geom,
+    land_ownership_polygons.createdAt AS polyCreatedAt,
+    land_ownership_polygons.updatedAt AS polyUpdatedAt
+  FROM land_ownerships
+  INNER JOIN land_ownership_polygons
+    ON land_ownerships.title_no = land_ownership_polygons.title_no
+  WHERE land_ownerships.proprietor_name_1 = ?
+     OR land_ownerships.proprietor_name_2 = ?
+     OR land_ownerships.proprietor_name_3 = ?
+     OR land_ownerships.proprietor_name_4 = ?;`;
+
+  const polygonsAndOwnerships = await sequelize.query(query, {
+    replacements: [name, name, name, name],
+    type: QueryTypes.SELECT,
   });
 
-  return polygonsAndOwnerships.map((polyAndOwn) => {
-    const poly = {
-      ...polyAndOwn,
-      poly_id: polyAndOwn["Polygon.poly_id"],
-      geom: polyAndOwn["Polygon.geom"],
-    };
-
-    delete poly["Polygon.poly_id"];
-    delete poly["Polygon.geom"];
-    delete poly["Polygon.id"];
-    delete poly["Polygon.title_no"];
-
-    return poly;
-  });
+  return polygonsAndOwnerships;
 };
 
 /** Create an entry in the pipeline_runs table, store and return its unique key */


### PR DESCRIPTION
#### What? Why?

Fixes https://github.com/DigitalCommons/land-explorer-front-end/issues/387

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
When doing a backsearch previously, we were doing ownerships LEFT JOIN polygons ON title_no, for ownerhsips that matched the proprietor name. This returned an array to the LX backend that included some ownerships with no associated polys.

Previously, this was then dealt with in the LX FE, by ignoring any titles with null geometry. However, this code changed since updating the backsearch UI to show titles rather than individual polys.
It makes sense to fix this bug at the source, here in the PBS, so that it never returns titles with null geometry in the first place. We achieve this by doing an INNER JOIN rather than a LEFT JOIN.

#### Checklist

- No docs changes needed
- UTs are not appropriate to test this
- [x] Checked that all automated tests pass

#### What should we test? (for QA)

<!-- List which features should be tested and how.
     Also think of other parts of the pipeline or LX app which could be affected
     by your change. -->

Do backsearch on these owners that were previously failing:
- Wykeham Trustees Limited
- Yorkshire water
- Red Kite properties

#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to
     ensure the PR behaves correctly? -->
