### PR TITLE
Add proprietors endpoint

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -16,3 +16,4 @@ MATRIX_WEBHOOK_URL=
 
 MEILI_HOST=http://localhost:7700
 MEILI_MASTER_KEY=test-master-key
+MEILISEARCH_ENABLED=true

--- a/docs/meilisearch.md
+++ b/docs/meilisearch.md
@@ -11,6 +11,14 @@ This starts the Meilisearch container on port 7700. The web dashboard is availab
 
 Data is stored in a named Docker volume (`meilisearch_data`) and persists across container restarts.
 
+### Deployed Docker Setup
+
+Meilisearch runs on the same servers as the property boundaries service - dev-2, staging-2, and prod-2. It is deployed as a Docker container via the Ansible playbook in the `technology-and-infrastructure` repo.
+
+The `MEILI_MASTER_KEY` for each environment is stored in the password store and is passed to the container by the Ansible playbook. 
+
+Unlike the local setup, deployed instances run with `MEILI_ENV=production`, which disables the web dashboard and requires authentication for all API calls.
+
 ### Client
 The Meilisearch client is initialised in the `start()` method of `app.ts`. It connects to Meilisearch using the master key, retrieves the auto-generated 'Default Admin API Key', and uses this key to set up the client for backend queries.
 
@@ -68,5 +76,5 @@ Example response:
 }
 ```
 
-The endpoint supports request abortion — if the client closes the connection, the in-flight
+The endpoint supports request abortion - if the client closes the connection, the in-flight
 Meilisearch query is cancelled via an `AbortController` signal.

--- a/docs/meilisearch.md
+++ b/docs/meilisearch.md
@@ -21,3 +21,52 @@ To use this client, call
 getMeiliClient();
 ```
 from `src/meilisearch/client.js`
+
+### API endpoint
+
+`GET /api/proprietors`
+
+This endpoint is backed by Meilisearch. When called, it queries the `proprietors` index using the provided `searchTerm` and returns a paginated slice of matching documents. Meilisearch handles fuzzy matching, so partial or misspelled names will still return relevant results.
+
+The flow is:
+
+```
+Frontend → LX Backend → GET /api/proprietors → Meilisearch (proprietors index)
+```
+
+If the Meilisearch client has not been initialised (e.g. Meilisearch is unavailable at startup), the endpoint returns a 500 error.
+
+Headers:
+
+| Header      | Required | Description                   |
+|-------------|----------|-------------------------------|
+| `x-api-key` | Yes      | API secret for authentication |
+
+Query parameters:
+
+| Parameter    | Required | Default | Description                              |
+|--------------|----------|---------|------------------------------------------|
+| `searchTerm` | Yes      | —       | The name (or partial name) to search for |
+| `page`       | No       | `1`     | Page number (positive integer)           |
+| `pageSize`   | No       | `10`    | Results per page (1–100)                 |
+
+Example request:
+```
+GET /api/proprietors?searchTerm=Cambri&page=1&pageSize=10
+x-api-key: <secret>
+```
+
+Example response:
+```json
+{
+  "results": [
+    { "id": 1, "proprietorName": "Cambridge Council" }
+  ],
+  "page": 1,
+  "pageSize": 10,
+  "totalResults": 3453
+}
+```
+
+The endpoint supports request abortion — if the client closes the connection, the in-flight
+Meilisearch query is cancelled via an `AbortController` signal.

--- a/docs/meilisearch.md
+++ b/docs/meilisearch.md
@@ -36,10 +36,10 @@ The `proprietors` Meilisearch index holds all distinct proprietor names from the
 
 Each document has the shape:
 ```json
-{ "id": 123456789, "name": "Some Company Ltd" }
+{ "id": "a1b2c3d4e5f60718", "name": "Some Company Ltd" }
 ```
 
-The `id` is derived from a SHA-256 hash of the name, so it is consistent across pipeline runs.
+The `id` is the first 16 hex characters of a SHA-256 hash of the name, so it is consistent across pipeline runs.
 
 #### Updating the index
 
@@ -78,12 +78,6 @@ Frontend → LX Backend → GET /api/proprietors → Meilisearch (proprietors in
 
 If the Meilisearch client has not been initialised (e.g. Meilisearch is unavailable at startup), the endpoint returns a 500 error.
 
-Headers:
-
-| Header      | Required | Description                   |
-|-------------|----------|-------------------------------|
-| `x-api-key` | Yes      | API secret for authentication |
-
 Query parameters:
 
 | Parameter    | Required | Default | Description                              |
@@ -91,18 +85,18 @@ Query parameters:
 | `searchTerm` | Yes      | —       | The name (or partial name) to search for |
 | `page`       | No       | `1`     | Page number (positive integer)           |
 | `pageSize`   | No       | `10`    | Results per page (1–100)                 |
+| `secret`     | Yes      | —       | API secret for authentication            |
 
 Example request:
 ```
-GET /api/proprietors?searchTerm=Cambri&page=1&pageSize=10
-x-api-key: <secret>
+GET /api/proprietors?searchTerm=Cambri&page=1&pageSize=10&secret=<secret>
 ```
 
 Example response:
 ```json
 {
   "results": [
-    { "id": 1, "proprietorName": "Cambridge Council" }
+    { "id": "a1b2c3d4e5f60718", "proprietorName": "Cambridge Council" }
   ],
   "page": 1,
   "pageSize": 10,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "csv-parser": "^3.0.0",
         "dotenv": "^16.3.1",
         "extract-zip": "^2.0.1",
+        "joi": "^18.1.2",
         "lodash.chunk": "^4.2.0",
         "meilisearch": "^0.56.0",
         "moment-timezone": "^0.5.43",
@@ -83,6 +84,18 @@
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@hapi/ammo": {
@@ -176,6 +189,12 @@
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
       "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
     },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@hapi/hapi": {
       "version": "21.3.2",
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.2.tgz",
@@ -215,9 +234,10 @@
       }
     },
     "node_modules/@hapi/hoek": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.2.tgz",
-      "integrity": "sha512-aKmlCO57XFZ26wso4rJsW4oTUnrgTFw2jh3io7CAtO9w4UltBNwRXvXIVzzyfkaaLRo3nluP/19msA8vDUUuKw=="
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/iron": {
       "version": "7.0.1",
@@ -263,6 +283,12 @@
         "@hapi/hoek": "^11.0.2",
         "@hapi/nigel": "^5.0.1"
       }
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/podium": {
       "version": "5.0.1",
@@ -324,6 +350,15 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
       "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -548,6 +583,12 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -4355,6 +4396,24 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/joi": {
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
+      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/js-beautify": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "csv-parser": "^3.0.0",
     "dotenv": "^16.3.1",
     "extract-zip": "^2.0.1",
+    "joi": "^18.1.2",
     "lodash.chunk": "^4.2.0",
     "meilisearch": "^0.56.0",
     "moment-timezone": "^0.5.43",

--- a/src/meilisearch/client.test.ts
+++ b/src/meilisearch/client.test.ts
@@ -126,7 +126,7 @@ describe("MeiliSearch Client", () => {
 
       // Act
       await initMeiliSearch();
-      const meiliClientInstance = await getMeiliClient();
+      const meiliClientInstance = getMeiliClient();
 
       // Assert
       expect(meiliClientInstance).to.equal(mockInstance);

--- a/src/meilisearch/client.ts
+++ b/src/meilisearch/client.ts
@@ -7,6 +7,9 @@ let meiliClient: MeiliSearch | null = null;
 
 export async function initMeiliSearch(): Promise<void> {
   logger.info("Initialising MeiliSearch client...");
+  if (!process.env.MEILI_HOST || !process.env.MEILI_MASTER_KEY) {
+    throw new Error("MeiliSearch host or master key not configured");
+  }
   const masterClient = new MeiliSearch({
     host: process.env.MEILI_HOST,
     apiKey: process.env.MEILI_MASTER_KEY,

--- a/src/pipeline/proprietors/update.test.ts
+++ b/src/pipeline/proprietors/update.test.ts
@@ -314,5 +314,42 @@ describe("update proprietors", () => {
         expect(mockMeiliClient.deleteIndex.called).to.be.true;
       }
     });
+
+    it("should skip update when MEILISEARCH_ENABLED is not 'true'", async () => {
+      //Arrange
+      const original = process.env.MEILISEARCH_ENABLED;
+      process.env.MEILISEARCH_ENABLED = "false";
+
+      try {
+        //Act
+        await update.updateProprietorsIndex();
+        //Assert
+        expect(getMeiliClientStub.called).to.be.false;
+        expect(mockMeiliClient.createIndex.called).to.be.false;
+      } finally {
+        process.env.MEILISEARCH_ENABLED = original;
+      }
+    });
+
+    it("should clean up new index on swap failure and rethrow", async () => {
+      //Arrange
+      getDistinctProprietorNamesStub.resolves(["Owner 1"]);
+      const failedTask = {
+        status: "failed",
+        error: { message: "Swap failed" },
+      };
+      mockMeiliClient.swapIndexes.returns({
+        waitTask: sandbox.stub().resolves(failedTask),
+      });
+
+      //Act & Assert
+      try {
+        await update.updateProprietorsIndex();
+        expect.fail("Should have thrown an error");
+      } catch (err: any) {
+        expect(err.message).to.include("Failed to swap");
+        expect(mockMeiliClient.deleteIndex.called).to.be.true;
+      }
+    });
   });
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -275,7 +275,7 @@ const routes = [
   getPolygonsRoute,
   searchRoute,
   runPipelineRoute,
-  proprietorsRoute,
+  ...(process.env.MEILISEARCH_ENABLED === "true" ? [proprietorsRoute] : []),
   // postTestDataRoute
 ];
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -17,6 +17,7 @@ import {
   Geometry,
 } from "../queries/query.js";
 import { PipelineOptions, triggerPipelineRun } from "../pipeline/run.js";
+import { proprietorsRoute } from "./proprietors/proprietors.js";
 
 type GetPolygonsInBoxRequest = Request & {
   query: {
@@ -274,6 +275,7 @@ const routes = [
   getPolygonsRoute,
   searchRoute,
   runPipelineRoute,
+  proprietorsRoute,
   // postTestDataRoute
 ];
 

--- a/src/routes/proprietors/proprietors.test.ts
+++ b/src/routes/proprietors/proprietors.test.ts
@@ -67,6 +67,7 @@ describe("GET /api/proprietors", () => {
 
   describe("authentication", () => {
     it("returns 403 when x-api-key header is missing", async () => {
+      // Arrange
       const { getMeiliClientStub } = buildMeiliMock(sandbox);
       const { getProprietors } = await esmock("./proprietors.js", {
         "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
@@ -75,12 +76,15 @@ describe("GET /api/proprietors", () => {
       const request = buildRequest({}, { "x-api-key": undefined });
       const h = buildH();
 
+      // Act
       const result = await getProprietors(request, h);
 
+      // Assert
       expect(result.statusCode).to.equal(403);
     });
 
     it("returns 403 when x-api-key header is incorrect", async () => {
+      // Arrange
       const { getMeiliClientStub } = buildMeiliMock(sandbox);
       const { getProprietors } = await esmock("./proprietors.js", {
         "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
@@ -89,32 +93,40 @@ describe("GET /api/proprietors", () => {
       const request = buildRequest({}, { "x-api-key": "wrong-secret" });
       const h = buildH();
 
+      // Act
       const result = await getProprietors(request, h);
 
+      // Assert
       expect(result.statusCode).to.equal(403);
     });
   });
 
   describe("successful response", () => {
     it("returns 200 with correctly shaped results", async () => {
+      // Arrange
       const hits = [
         { id: 1, name: "Cambridge Council" },
         { id: 2, name: "Cambridge University" },
       ];
-      const { getMeiliClientStub } = buildMeiliMock(sandbox, {
-        hits,
-        totalHits: 2,
-      });
+      const { getMeiliClientStub, indexStub, searchStub } = buildMeiliMock(
+        sandbox,
+        {
+          hits,
+          totalHits: 2,
+        },
+      );
 
       const { getProprietors } = await esmock("./proprietors.js", {
         "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
       });
 
-      const request = buildRequest();
+      const request = buildRequest({ searchTerm: "Cambridge" });
       const h = buildH();
 
+      // Act
       const result = await getProprietors(request, h);
 
+      // Assert
       expect(result.statusCode).to.equal(200);
       expect(result.payload).to.deep.equal({
         results: [
@@ -127,7 +139,8 @@ describe("GET /api/proprietors", () => {
       });
     });
 
-    it("passes page and pageSize to MeiliSearch", async () => {
+    it("passes searchTerm, page and pageSize to MeiliSearch", async () => {
+      // Arrange
       const { getMeiliClientStub, searchStub } = buildMeiliMock(sandbox, {
         hits: [],
         totalHits: 100,
@@ -137,39 +150,29 @@ describe("GET /api/proprietors", () => {
         "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
       });
 
-      const request = buildRequest({ page: 3, pageSize: 10 });
-      const h = buildH();
-
-      await getProprietors(request, h);
-
-      expect(searchStub.firstCall.args[1]).to.deep.include({
-        hitsPerPage: 10,
+      const request = buildRequest({
+        searchTerm: "Cambri",
         page: 3,
+        pageSize: 10,
       });
-    });
-
-    it("passes searchTerm to MeiliSearch", async () => {
-      const { getMeiliClientStub, searchStub, indexStub } = buildMeiliMock(
-        sandbox,
-        { hits: [], totalHits: 0 },
-      );
-
-      const { getProprietors } = await esmock("./proprietors.js", {
-        "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
-      });
-
-      const request = buildRequest({ searchTerm: "Cambri" });
       const h = buildH();
 
+      // Act
       await getProprietors(request, h);
 
-      expect(indexStub.calledWith("proprietors")).to.be.true;
-      expect(searchStub.firstCall.args[0]).to.equal("Cambri");
+      // Assert
+      expect(
+        searchStub.calledWith("Cambri", {
+          hitsPerPage: 10,
+          page: 3,
+        }),
+      ).to.be.true;
     });
   });
 
   describe("error handling", () => {
     it("returns 500 when MeiliSearch throws an error", async () => {
+      // Arrange
       const searchStub = sandbox
         .stub()
         .rejects(new Error("MeiliSearch unavailable"));
@@ -183,13 +186,16 @@ describe("GET /api/proprietors", () => {
       const request = buildRequest();
       const h = buildH();
 
+      // Act
       const result = await getProprietors(request, h);
 
+      // Assert
       expect(result.statusCode).to.equal(500);
       expect(result.payload).to.equal("Internal server error");
     });
 
     it("returns 500 when MeiliSearch client is not initialised", async () => {
+      // Arrange
       const getMeiliClientStub = sandbox
         .stub()
         .throws(new Error("MeiliSearch client not initialised"));
@@ -201,9 +207,12 @@ describe("GET /api/proprietors", () => {
       const request = buildRequest();
       const h = buildH();
 
+      // Act
       const result = await getProprietors(request, h);
 
+      // Assert
       expect(result.statusCode).to.equal(500);
+      expect(result.payload).to.equal("Internal server error");
     });
   });
 
@@ -223,10 +232,10 @@ describe("GET /api/proprietors", () => {
       const h = buildH();
 
       req.emit("close");
-
       const result = await getProprietors(request, h);
 
       expect(result.statusCode).to.equal(499);
+      expect(result.payload).to.equal("Request aborted");
     });
   });
 });

--- a/src/routes/proprietors/proprietors.test.ts
+++ b/src/routes/proprietors/proprietors.test.ts
@@ -1,0 +1,232 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { EventEmitter } from "events";
+
+const buildRequest = (
+  query: Record<string, string | number | undefined> = {},
+  headers: Record<string, string | undefined> = {},
+  req: EventEmitter = new EventEmitter(),
+) => ({
+  query: {
+    searchTerm: "Cambridge",
+    page: 1,
+    pageSize: 10,
+    ...query,
+  },
+  headers: {
+    "x-api-key": process.env.SECRET,
+    ...headers,
+  },
+  raw: { req },
+});
+
+const buildH = () => {
+  const responses: { payload: any; statusCode: number }[] = [];
+  const h = {
+    response: (payload?: any) => {
+      const res = {
+        payload,
+        statusCode: 200,
+        code(statusCode: number) {
+          this.statusCode = statusCode;
+          return this;
+        },
+      };
+      responses.push(res);
+      return res;
+    },
+    responses,
+  };
+  return h;
+};
+
+describe("GET /api/proprietors", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const buildMeiliMock = (
+    sandbox: sinon.SinonSandbox,
+    searchResult: {
+      hits: any[];
+      totalHits?: number;
+    } = { hits: [], totalHits: 0 },
+  ) => {
+    const searchStub = sandbox.stub().resolves(searchResult);
+    const indexStub = sandbox.stub().returns({ search: searchStub });
+    const getMeiliClientStub = sandbox.stub().returns({ index: indexStub });
+    return { searchStub, indexStub, getMeiliClientStub };
+  };
+
+  describe("authentication", () => {
+    it("returns 403 when x-api-key header is missing", async () => {
+      const { getMeiliClientStub } = buildMeiliMock(sandbox);
+      const { getProprietors } = await esmock("./proprietors.js", {
+        "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
+      });
+
+      const request = buildRequest({}, { "x-api-key": undefined });
+      const h = buildH();
+
+      const result = await getProprietors(request, h);
+
+      expect(result.statusCode).to.equal(403);
+    });
+
+    it("returns 403 when x-api-key header is incorrect", async () => {
+      const { getMeiliClientStub } = buildMeiliMock(sandbox);
+      const { getProprietors } = await esmock("./proprietors.js", {
+        "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
+      });
+
+      const request = buildRequest({}, { "x-api-key": "wrong-secret" });
+      const h = buildH();
+
+      const result = await getProprietors(request, h);
+
+      expect(result.statusCode).to.equal(403);
+    });
+  });
+
+  describe("successful response", () => {
+    it("returns 200 with correctly shaped results", async () => {
+      const hits = [
+        { id: 1, name: "Cambridge Council" },
+        { id: 2, name: "Cambridge University" },
+      ];
+      const { getMeiliClientStub } = buildMeiliMock(sandbox, {
+        hits,
+        totalHits: 2,
+      });
+
+      const { getProprietors } = await esmock("./proprietors.js", {
+        "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
+      });
+
+      const request = buildRequest();
+      const h = buildH();
+
+      const result = await getProprietors(request, h);
+
+      expect(result.statusCode).to.equal(200);
+      expect(result.payload).to.deep.equal({
+        results: [
+          { id: 1, proprietorName: "Cambridge Council" },
+          { id: 2, proprietorName: "Cambridge University" },
+        ],
+        page: 1,
+        pageSize: 10,
+        totalResults: 2,
+      });
+    });
+
+    it("passes page and pageSize to MeiliSearch", async () => {
+      const { getMeiliClientStub, searchStub } = buildMeiliMock(sandbox, {
+        hits: [],
+        totalHits: 100,
+      });
+
+      const { getProprietors } = await esmock("./proprietors.js", {
+        "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
+      });
+
+      const request = buildRequest({ page: 3, pageSize: 10 });
+      const h = buildH();
+
+      await getProprietors(request, h);
+
+      expect(searchStub.firstCall.args[1]).to.deep.include({
+        hitsPerPage: 10,
+        page: 3,
+      });
+    });
+
+    it("passes searchTerm to MeiliSearch", async () => {
+      const { getMeiliClientStub, searchStub, indexStub } = buildMeiliMock(
+        sandbox,
+        { hits: [], totalHits: 0 },
+      );
+
+      const { getProprietors } = await esmock("./proprietors.js", {
+        "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
+      });
+
+      const request = buildRequest({ searchTerm: "Cambri" });
+      const h = buildH();
+
+      await getProprietors(request, h);
+
+      expect(indexStub.calledWith("proprietors")).to.be.true;
+      expect(searchStub.firstCall.args[0]).to.equal("Cambri");
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns 500 when MeiliSearch throws an error", async () => {
+      const searchStub = sandbox
+        .stub()
+        .rejects(new Error("MeiliSearch unavailable"));
+      const indexStub = sandbox.stub().returns({ search: searchStub });
+      const getMeiliClientStub = sandbox.stub().returns({ index: indexStub });
+
+      const { getProprietors } = await esmock("./proprietors.js", {
+        "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
+      });
+
+      const request = buildRequest();
+      const h = buildH();
+
+      const result = await getProprietors(request, h);
+
+      expect(result.statusCode).to.equal(500);
+      expect(result.payload).to.equal("Internal server error");
+    });
+
+    it("returns 500 when MeiliSearch client is not initialised", async () => {
+      const getMeiliClientStub = sandbox
+        .stub()
+        .throws(new Error("MeiliSearch client not initialised"));
+
+      const { getProprietors } = await esmock("./proprietors.js", {
+        "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
+      });
+
+      const request = buildRequest();
+      const h = buildH();
+
+      const result = await getProprietors(request, h);
+
+      expect(result.statusCode).to.equal(500);
+    });
+  });
+
+  describe("abort handling", () => {
+    it("returns 499 when the request is aborted", async () => {
+      const req = new EventEmitter();
+      const abortError = new DOMException("Aborted", "AbortError");
+      const searchStub = sandbox.stub().rejects(abortError);
+      const indexStub = sandbox.stub().returns({ search: searchStub });
+      const getMeiliClientStub = sandbox.stub().returns({ index: indexStub });
+
+      const { getProprietors } = await esmock("./proprietors.js", {
+        "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
+      });
+
+      const request = buildRequest({}, {}, req);
+      const h = buildH();
+
+      req.emit("close");
+
+      const result = await getProprietors(request, h);
+
+      expect(result.statusCode).to.equal(499);
+    });
+  });
+});

--- a/src/routes/proprietors/proprietors.test.ts
+++ b/src/routes/proprietors/proprietors.test.ts
@@ -132,6 +132,33 @@ describe("GET /api/proprietors", () => {
       });
     });
 
+    it("returns 200 with empty results array when there are no hits", async () => {
+      // Arrange
+      const { getMeiliClientStub } = buildMeiliMock(sandbox, {
+        hits: [],
+        totalHits: 0,
+      });
+
+      const { getProprietors } = await esmock("./proprietors.js", {
+        "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
+      });
+
+      const request = buildRequest({ searchTerm: "Xyzzy" });
+      const h = buildH();
+
+      // Act
+      const result = await getProprietors(request, h);
+
+      // Assert
+      expect(result.statusCode).to.equal(200);
+      expect(result.payload).to.deep.equal({
+        results: [],
+        page: 1,
+        pageSize: 10,
+        totalResults: 0,
+      });
+    });
+
     it("passes searchTerm, page and pageSize to MeiliSearch", async () => {
       // Arrange
       const { getMeiliClientStub, searchStub } = buildMeiliMock(sandbox, {
@@ -160,6 +187,27 @@ describe("GET /api/proprietors", () => {
           page: 3,
         }),
       ).to.be.true;
+    });
+
+    it("searches the correct MeiliSearch index", async () => {
+      // Arrange
+      const { getMeiliClientStub, indexStub } = buildMeiliMock(sandbox);
+
+      const { getProprietors, PROPRIETORS_INDEX } = await esmock(
+        "./proprietors.js",
+        {
+          "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
+        },
+      );
+
+      const request = buildRequest();
+      const h = buildH();
+
+      // Act
+      await getProprietors(request, h);
+
+      // Assert
+      expect(indexStub.calledWith(PROPRIETORS_INDEX)).to.be.true;
     });
   });
 
@@ -211,9 +259,13 @@ describe("GET /api/proprietors", () => {
 
   describe("abort handling", () => {
     it("returns 499 when the request is aborted", async () => {
+      // Arrange
       const req = new EventEmitter();
-      const abortError = new DOMException("Aborted", "AbortError");
-      const searchStub = sandbox.stub().rejects(abortError);
+      let rejectSearch!: (err: Error) => void;
+      const searchPromise = new Promise<never>((_, reject) => {
+        rejectSearch = reject;
+      });
+      const searchStub = sandbox.stub().returns(searchPromise);
       const indexStub = sandbox.stub().returns({ search: searchStub });
       const getMeiliClientStub = sandbox.stub().returns({ index: indexStub });
 
@@ -224,8 +276,13 @@ describe("GET /api/proprietors", () => {
       const request = buildRequest({}, req);
       const h = buildH();
 
+      // Start the handler so the close listener is registered, then abort and reject
+      //Act
+      const resultPromise = getProprietors(request, h);
       req.emit("close");
-      const result = await getProprietors(request, h);
+      rejectSearch(new Error("connection reset"));
+      // Assert
+      const result = await resultPromise;
 
       expect(result.statusCode).to.equal(499);
       expect(result.payload).to.equal("Request aborted");

--- a/src/routes/proprietors/proprietors.test.ts
+++ b/src/routes/proprietors/proprietors.test.ts
@@ -5,18 +5,14 @@ import { EventEmitter } from "events";
 
 const buildRequest = (
   query: Record<string, string | number | undefined> = {},
-  headers: Record<string, string | undefined> = {},
   req: EventEmitter = new EventEmitter(),
 ) => ({
   query: {
     searchTerm: "Cambridge",
     page: 1,
     pageSize: 10,
+    secret: process.env.SECRET,
     ...query,
-  },
-  headers: {
-    "x-api-key": process.env.SECRET,
-    ...headers,
   },
   raw: { req },
 });
@@ -66,14 +62,14 @@ describe("GET /api/proprietors", () => {
   };
 
   describe("authentication", () => {
-    it("returns 403 when x-api-key header is missing", async () => {
+    it("returns 403 when secret is missing", async () => {
       // Arrange
       const { getMeiliClientStub } = buildMeiliMock(sandbox);
       const { getProprietors } = await esmock("./proprietors.js", {
         "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
       });
 
-      const request = buildRequest({}, { "x-api-key": undefined });
+      const request = buildRequest({ secret: undefined });
       const h = buildH();
 
       // Act
@@ -83,14 +79,14 @@ describe("GET /api/proprietors", () => {
       expect(result.statusCode).to.equal(403);
     });
 
-    it("returns 403 when x-api-key header is incorrect", async () => {
+    it("returns 403 when secret is incorrect", async () => {
       // Arrange
       const { getMeiliClientStub } = buildMeiliMock(sandbox);
       const { getProprietors } = await esmock("./proprietors.js", {
         "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
       });
 
-      const request = buildRequest({}, { "x-api-key": "wrong-secret" });
+      const request = buildRequest({ secret: "wrongsecret" });
       const h = buildH();
 
       // Act
@@ -102,19 +98,16 @@ describe("GET /api/proprietors", () => {
   });
 
   describe("successful response", () => {
-    it("returns 200 with correctly shaped results", async () => {
+    it.only("returns 200 with correctly shaped results", async () => {
       // Arrange
       const hits = [
         { id: 1, name: "Cambridge Council" },
         { id: 2, name: "Cambridge University" },
       ];
-      const { getMeiliClientStub, indexStub, searchStub } = buildMeiliMock(
-        sandbox,
-        {
-          hits,
-          totalHits: 2,
-        },
-      );
+      const { getMeiliClientStub } = buildMeiliMock(sandbox, {
+        hits,
+        totalHits: 2,
+      });
 
       const { getProprietors } = await esmock("./proprietors.js", {
         "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
@@ -228,7 +221,7 @@ describe("GET /api/proprietors", () => {
         "../../meilisearch/client.js": { getMeiliClient: getMeiliClientStub },
       });
 
-      const request = buildRequest({}, {}, req);
+      const request = buildRequest({}, req);
       const h = buildH();
 
       req.emit("close");

--- a/src/routes/proprietors/proprietors.test.ts
+++ b/src/routes/proprietors/proprietors.test.ts
@@ -98,7 +98,7 @@ describe("GET /api/proprietors", () => {
   });
 
   describe("successful response", () => {
-    it.only("returns 200 with correctly shaped results", async () => {
+    it("returns 200 with correctly shaped results", async () => {
       // Arrange
       const hits = [
         { id: 1, name: "Cambridge Council" },

--- a/src/routes/proprietors/proprietors.ts
+++ b/src/routes/proprietors/proprietors.ts
@@ -13,6 +13,7 @@ export const PROPRIETORS_INDEX = "proprietors";
 const DEFAULT_PAGE = 1;
 const DEFAULT_PAGE_SIZE = 10;
 const MAX_PAGE_SIZE = 100;
+const MAX_SEARCH_TERM_LENGTH = 200;
 
 type GetProprietorsRequest = Request & {
   query: {
@@ -86,7 +87,7 @@ export const getProprietors = async (
 };
 
 const querySchema = Joi.object({
-  searchTerm: Joi.string().min(1).required(),
+  searchTerm: Joi.string().min(1).max(MAX_SEARCH_TERM_LENGTH).required(),
   page: Joi.number().integer().min(1).optional().default(DEFAULT_PAGE),
   pageSize: Joi.number()
     .integer()
@@ -105,9 +106,11 @@ export const proprietorsRoute: ServerRoute = {
     auth: false,
     validate: {
       query: querySchema,
-      failAction: async (_request, _h, err) => {
-        throw err;
-      },
+      failAction: (request, h, err) =>
+        h
+          .response({ message: (err as Error).message })
+          .code(400)
+          .takeover(),
     },
   },
 };

--- a/src/routes/proprietors/proprietors.ts
+++ b/src/routes/proprietors/proprietors.ts
@@ -1,0 +1,111 @@
+import {
+  ServerRoute,
+  Request,
+  ResponseObject,
+  ResponseToolkit,
+} from "@hapi/hapi";
+import { getMeiliClient } from "../../meilisearch/client.js";
+import Joi from "joi";
+import { logger } from "../../pipeline/logger.js";
+
+export const PROPRIETORS_INDEX = "proprietors";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 10;
+const MAX_PAGE_SIZE = 100;
+
+type GetProprietorsRequest = Request & {
+  query: {
+    searchTerm: string;
+    page: number;
+    pageSize: number;
+  };
+};
+
+type ProprietorRecord = {
+  id: number;
+  name: string;
+};
+
+/**
+ * Searches the proprietors index in MeiliSearch and returns a paginated list of results.
+ * @param request The incoming request, containing `searchTerm`, `page`, and `pageSize` query params and an `x-api-key` header
+ * @param h The Hapi response toolkit
+ * @returns A paginated response containing matched proprietors, or an error response
+ */
+export const getProprietors = async (
+  request: GetProprietorsRequest,
+  h: ResponseToolkit,
+): Promise<ResponseObject> => {
+  const { searchTerm, page, pageSize } = request.query;
+  const secret = request.headers["x-api-key"];
+
+  if (!secret || secret !== process.env.SECRET) {
+    return h.response().code(403);
+  }
+
+  const abortController = new AbortController();
+  request.raw.req.on("close", () => {
+    abortController.abort();
+  });
+
+  try {
+    const meiliClient = getMeiliClient();
+    const { hits, totalHits } = await meiliClient
+      .index<ProprietorRecord>(PROPRIETORS_INDEX)
+      .search(
+        searchTerm,
+        {
+          hitsPerPage: pageSize,
+          page,
+        },
+        { signal: abortController.signal },
+      );
+
+    const results = hits.map((hit) => ({
+      id: hit.id,
+      proprietorName: hit.name,
+    }));
+
+    return h
+      .response({
+        results,
+        page,
+        pageSize,
+        totalResults: totalHits,
+      })
+      .code(200);
+  } catch (error: any) {
+    if (abortController.signal.aborted || error.name === "AbortError") {
+      return h.response("Request aborted").code(499);
+    }
+    logger.error("Error searching proprietors:", error);
+    return h.response("Internal server error").code(500);
+  }
+};
+
+const querySchema = Joi.object({
+  searchTerm: Joi.string().required(),
+  page: Joi.number().integer().min(1).optional().default(DEFAULT_PAGE),
+  pageSize: Joi.number()
+    .integer()
+    .min(1)
+    .max(MAX_PAGE_SIZE)
+    .optional()
+    .default(DEFAULT_PAGE_SIZE),
+});
+
+export const proprietorsRoute: ServerRoute = {
+  method: "GET",
+  path: "/api/proprietors",
+  handler: getProprietors,
+  options: {
+    auth: false,
+    validate: {
+      query: querySchema,
+      failAction: async (_request, _h, err) => {
+        throw err;
+      },
+    },
+  },
+};

--- a/src/routes/proprietors/proprietors.ts
+++ b/src/routes/proprietors/proprietors.ts
@@ -19,6 +19,7 @@ type GetProprietorsRequest = Request & {
     searchTerm: string;
     page: number;
     pageSize: number;
+    secret: string;
   };
 };
 
@@ -29,7 +30,7 @@ type ProprietorRecord = {
 
 /**
  * Searches the proprietors index in MeiliSearch and returns a paginated list of results.
- * @param request The incoming request, containing `searchTerm`, `page`, and `pageSize` query params and an `x-api-key` header
+ * @param request The incoming request, containing `searchTerm`, `page`, `pageSize` and api secret query params
  * @param h The Hapi response toolkit
  * @returns A paginated response containing matched proprietors, or an error response
  */
@@ -37,10 +38,9 @@ export const getProprietors = async (
   request: GetProprietorsRequest,
   h: ResponseToolkit,
 ): Promise<ResponseObject> => {
-  const { searchTerm, page, pageSize } = request.query;
-  const secret = request.headers["x-api-key"];
+  const { searchTerm, page, pageSize, secret } = request.query;
 
-  if (!secret || secret !== process.env.SECRET) {
+  if (secret !== process.env.SECRET) {
     return h.response().code(403);
   }
 
@@ -93,6 +93,7 @@ const querySchema = Joi.object({
     .max(MAX_PAGE_SIZE)
     .optional()
     .default(DEFAULT_PAGE_SIZE),
+  secret: Joi.string().required(),
 });
 
 export const proprietorsRoute: ServerRoute = {

--- a/src/routes/proprietors/proprietors.ts
+++ b/src/routes/proprietors/proprietors.ts
@@ -24,7 +24,7 @@ type GetProprietorsRequest = Request & {
 };
 
 type ProprietorRecord = {
-  id: number;
+  id: string;
   name: string;
 };
 
@@ -40,14 +40,13 @@ export const getProprietors = async (
 ): Promise<ResponseObject> => {
   const { searchTerm, page, pageSize, secret } = request.query;
 
-  if (secret !== process.env.SECRET) {
-    return h.response().code(403);
+  if (!secret || secret !== process.env.SECRET) {
+    return h.response("missing or incorrect secret").code(403);
   }
 
   const abortController = new AbortController();
-  request.raw.req.on("close", () => {
-    abortController.abort();
-  });
+  const onClose = () => abortController.abort();
+  request.raw.req.on("close", onClose);
 
   try {
     const meiliClient = getMeiliClient();
@@ -81,11 +80,13 @@ export const getProprietors = async (
     }
     logger.error("Error searching proprietors:", error);
     return h.response("Internal server error").code(500);
+  } finally {
+    request.raw.req.off("close", onClose);
   }
 };
 
 const querySchema = Joi.object({
-  searchTerm: Joi.string().required(),
+  searchTerm: Joi.string().min(1).required(),
   page: Joi.number().integer().min(1).optional().default(DEFAULT_PAGE),
   pageSize: Joi.number()
     .integer()

--- a/src/routes/proprietors/proprietors.ts
+++ b/src/routes/proprietors/proprietors.ts
@@ -100,7 +100,7 @@ const querySchema = Joi.object({
 
 export const proprietorsRoute: ServerRoute = {
   method: "GET",
-  path: "/api/proprietors",
+  path: "/proprietors",
   handler: getProprietors,
   options: {
     auth: false,


### PR DESCRIPTION
#### What? Why?

Related to issue [#81](https://github.com/DigitalCommons/land-explorer-back-end/issues/81)

This is part of the LX Backsearch epic. 
This part is to create an endpoint in the property boundaries service that gets proprietors for a search term, using meilisearch to do fuzzy searching.

#### Code-specific details (for Reviewer)
- I've installed the `joi` npm package for validating the query - it is recommended to use by Hapi https://hapi.dev/tutorials/validation/?lang=en_US


#### Checklist

- [x] Updated or added any necessary docs in `docs/`
- [x] Added UTs
- [x] Checked that all automated tests pass

#### What should we test? (for QA)
To test this endpoint:

`https://<dev/staging>.propertyboundaries.landexplorer.coop/api/proprietors?searchTerm=bristol cit&page=3&pageSize=5&secret=<SECRET>`
(page and pageSize are optional)

Alternatively, once the whole epic is deployed, this can be tested using the search box in the UI

#### Deployment notes
This is behind a feature flag (`MEILISEARCH_ENABLED` env var) so will initially be deployed switched off until the meilisearch infrastructure is in place

