### PR TITLE
Backsearch/move proprietor update pipeline task

### DIFF
--- a/docs/meilisearch.md
+++ b/docs/meilisearch.md
@@ -43,7 +43,7 @@ The `id` is the first 16 hex characters of a SHA-256 hash of the name, so it is 
 
 #### Updating the index
 
-The proprietors index is rebuilt automatically at the end of each full pipeline run (`updateProprietors` task). The process is:
+The proprietors index is rebuilt automatically in the pipeline run (`updateProprietors` task). The process is:
 
 1. Ensure the live `proprietors` index exists (create it if not).
 2. Delete any leftover `proprietors_new` index from a previous failed run.
@@ -56,13 +56,13 @@ If anything fails, `proprietors_new` is cleaned up and the live `proprietors` in
 
 #### Refreshing the index standalone
 
-To rebuild the proprietors index without running the full pipeline, pass `startAtTask=updateProprietors` to the `/run-pipeline` endpoint (currently there is no endOfTask parameter needed as this is the last task in the list but double check this):
+To rebuild the proprietors index without running the full pipeline, pass `startAtTask=updateProprietors` and `stopBeforeTask=downloadInspire` to the `/run-pipeline` endpoint.
 
 ```
-GET /run-pipeline?secret=<SECRET>&startAtTask=updateProprietors
+GET /run-pipeline?secret=<SECRET>&startAtTask=updateProprietors&stopBeforeTask=downloadInspire
 ```
 
-This starts from the `updateProprietors` task only, using the existing data already in `land_ownerships`.
+This runs the `updateProprietors` task only, using the existing data already in `land_ownerships`.
 
 ### API endpoint
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -111,6 +111,22 @@ It runs these tasks in sequential order:
     ownership data. This stage is quite fast and non-destructive, since the government API provides all
     historical data since Nov 2017, so the new data is always written straight into the DB.
 
+1. `updateProprietors`: This task rebuilds the Meilisearch `proprietors` search index from the `land_ownerships` data that was updated in the previous step, so that proprietor name search is kept up to date.
+
+    It works as follows:
+
+    1. Queries all distinct, non-empty proprietor names from the four proprietor name columns (`proprietor_name_1`–`proprietor_name_4`) in the `land_ownerships` table.
+    1. Converts each name into a document `{ id, name }`, where `id` is a 16-character hex prefix of the SHA-256 hash of the name.
+    1. Builds the new index:
+        - Creates the live `proprietors` index if it doesn't already exist (so the swap step later has something to swap into).
+        - Deletes any leftover `proprietors_new` index from a previously failed run.
+        - Creates a fresh `proprietors_new` index and configures `name` as its only searchable attribute.
+        - Inserts all documents into `proprietors_new` in batches of 10,000.
+        - Swaps `proprietors_new` into `proprietors`, making the new data live with minimal downtime.
+        - Deletes `proprietors_new` (which now holds the old data after the swap).
+    1. If any step fails, `proprietors_new` is cleaned up and the error is re-thrown, leaving the live `proprietors` index untouched.
+
+    
 1.  `downloadInspire`: This task
 
     1. downloads the latest INSPIRE data
@@ -177,6 +193,8 @@ are specific to DCC infrastructure, see [this GitHub comment](https://github.com
 ## Analysing the pipeline output
 
 After the `updateOwnerships` task is complete, the new company ownership data should be visible in LX for all users.
+
+After the `updateProprietors` task is complete, the Meilisearch proprietor index should be updated to match the proprietors in the Landownership table. These are visible to all users via the search bar in the LX frontend.
 
 After the `downloadOwnerships` task, a LX super user can see the pending INSPIRE polygons that have been downloaded in a separate, secret data layer.
 

--- a/src/pipeline/run.ts
+++ b/src/pipeline/run.ts
@@ -47,6 +47,11 @@ const tasks = [
     method: async (options: TaskOptions) => await updateOwnerships(options),
   },
   {
+    name: "updateProprietors",
+    desc: "Rebuild the Meilisearch proprietors index from the current land_ownerships data to keep proprietor search up to date.",
+    method: async (_options: TaskOptions) => await updateProprietorsIndex(),
+  },
+  {
     name: "downloadInspire",
     desc: "Download the latest INSPIRE polygons, backup the data, and store it in the pending_inspire_polygons DB table",
     method: async (options: TaskOptions) =>
@@ -57,11 +62,6 @@ const tasks = [
     desc: "Compare pending_inspire_polygons with the existing land_ownership_polygons and classify changes. Accept changes that meet criteria for a match and output detailed analysis about failed matches.",
     method: async (options: TaskOptions) =>
       await analyseAllPendingPolygons(options),
-  },
-  {
-    name: "updateProprietors",
-    desc: "Rebuild the Meilisearch proprietors index from the current land_ownerships data to keep proprietor search up to date.",
-    method: async (_options: TaskOptions) => await updateProprietorsIndex(),
   },
 ];
 


### PR DESCRIPTION
#### What? Why?

https://github.com/DigitalCommons/land-explorer-back-end/issues/85

Based on Rohit's comment:
https://github.com/DigitalCommons/property-boundaries-service/pull/36#discussion_r3123747355

I've moved where the `updateProprietors` task sits in the pipeline, so that it occurs straight after the ownerships task.
I've also updated the docs

#### Checklist

- [x] Updated or added any necessary docs in `docs/`
- [ ] Added UTs
- [x] Checked that all automated tests pass

#### What should we test? (for QA)

To test the specific pipeline task, call

`GET <PBS_API_URL>/run-pipeline?secret=<SECRET>&startAtTask=updateProprietors&stopBeforeTask=downloadInspire`

e.g. `GET https://staging.propertyboundaries.landexplorer.coop/api/run-pipeline?secret=<SECRET>&startAtTask=updateProprietors&stopBeforeTask=downloadInspire`

#### Deployment notes
- Ensure https://github.com/DigitalCommons/technology-and-infrastructure/pull/143 has been run successfully on the PBS server before this feature is switched on. This creates the Meilisearch infrastructure
- Add the following variables to the .env file:
```
MEILI_MASTER_KEY=<Key from password store>
MEILI_HOST=http://localhost:7700
MEILISEARCH_ENABLED=true
```
- Run the update proprietors section of the pipeline using:
`<PBS_API_URL>/run-pipeline?secret=<SECRET>&startAtTask=updateProprietors&stopBeforeTask=downloadInspire`