### PR TITLE
remove the MEILISEARCH_ENABLED feature flag

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -16,4 +16,3 @@ MATRIX_WEBHOOK_URL=
 
 MEILI_HOST=http://localhost:7700
 MEILI_MASTER_KEY=test-master-key
-MEILISEARCH_ENABLED=true

--- a/src/app.ts
+++ b/src/app.ts
@@ -49,14 +49,14 @@ async function start() {
 
   // initialise MeiliSearch client and check connection before starting to accept requests
   try {
-    if (process.env.MEILISEARCH_ENABLED === "true") {
-      await initMeiliSearch();
-    }
+    await initMeiliSearch();
   } catch (error) {
-    logger.error(
-      error,
-      `Failed to initialize MeiliSearch client: ${error.message}`,
-    );
+    if (error instanceof Error) {
+      logger.error(
+        error,
+        `Failed to initialize MeiliSearch client: ${error.message}`,
+      );
+    }
   }
 
   // Resume pipeline run if interrupted

--- a/src/pipeline/proprietors/update.test.ts
+++ b/src/pipeline/proprietors/update.test.ts
@@ -315,22 +315,6 @@ describe("update proprietors", () => {
       }
     });
 
-    it("should skip update when MEILISEARCH_ENABLED is not 'true'", async () => {
-      //Arrange
-      const original = process.env.MEILISEARCH_ENABLED;
-      process.env.MEILISEARCH_ENABLED = "false";
-
-      try {
-        //Act
-        await update.updateProprietorsIndex();
-        //Assert
-        expect(getMeiliClientStub.called).to.be.false;
-        expect(mockMeiliClient.createIndex.called).to.be.false;
-      } finally {
-        process.env.MEILISEARCH_ENABLED = original;
-      }
-    });
-
     it("should clean up new index on swap failure and rethrow", async () => {
       //Arrange
       getDistinctProprietorNamesStub.resolves(["Owner 1"]);

--- a/src/pipeline/proprietors/update.ts
+++ b/src/pipeline/proprietors/update.ts
@@ -178,12 +178,6 @@ async function updateSettings(
  * throughout the process.
  */
 export async function updateProprietorsIndex(): Promise<void> {
-  if (process.env.MEILISEARCH_ENABLED !== "true") {
-    logger.info(
-      "MeiliSearch is not enabled, skipping proprietors index update",
-    );
-    return;
-  }
   logger.info("Starting proprietors index update...");
   // Ensure the live index exists (create if absent, so we can swap into it)
   await createIndexIfNotExists(PROPRIETORS_INDEX);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -275,7 +275,7 @@ const routes = [
   getPolygonsRoute,
   searchRoute,
   runPipelineRoute,
-  ...(process.env.MEILISEARCH_ENABLED === "true" ? [proprietorsRoute] : []),
+  proprietorsRoute,
   // postTestDataRoute
 ];
 


### PR DESCRIPTION
#### What? Why?

https://github.com/DigitalCommons/land-explorer/issues/47

Chore to clean up MEILISEARCH_ENABLED feature flag now that backsearch work has been released for over a month

#### What should we test? (for QA)
Test the backsearch functionality still works ok

#### Deployment notes
Remove MEILISEARCH_ENABLED from .env file
